### PR TITLE
Fixing PoS reward checks; Fixing blockchain syncing; adding checkpoints

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -24,8 +24,13 @@ namespace Checkpoints
     //
     static MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
-    ( 0, hashGenesisBlockOfficial )
-	;
+    ( 0    , hashGenesisBlockOfficial )
+    ( 1250 , uint256("0x0000000359b5b9277d453f022ca265edf8020645b1658f660f12ff766744a93f"))
+    ( 2501 , uint256("0x8afe1140f179bcda864c44fdce62dd50adb79d8c0bd1f63622b5a99a8348da0d"))
+    ( 5000 , uint256("0xb6a1b5d19b58c0362695c3bd6f2d4d7db7ce92139afbeca75c6d202b8a50900e"))
+    ( 10000, uint256("0x294d1c92a73af3bf98da2992ef8727e9d05caa78b6f6ae1d2e646458107b51e2"))
+    ( 12500, uint256("0x4d85d52d6164fed450372d9d76210c4134596f06f5d758fca03c11ae3f0ce61d"))
+    ;
 
     static MapCheckpoints mapCheckpointsTestnet =
         boost::assign::map_list_of

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -8,7 +8,7 @@
 // These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       3
-#define CLIENT_VERSION_REVISION    0
+#define CLIENT_VERSION_REVISION    1
 #define CLIENT_VERSION_BUILD       0
 
 // This is the client version name, used by the GUI and server for version reporting

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -26,7 +26,7 @@ bool CheckStakeKernelHash(unsigned int nBits, const CBlock& blockFrom, unsigned 
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return
-bool CheckProofOfStake(const CTransaction& tx, unsigned int nBits, uint256& hashProofOfStake);
+bool CheckProofOfStake(const CTransaction& tx, int nHeight, unsigned int nBits, uint256& hashProofOfStake);
 
 // Check whether the coinstake timestamp meets protocol
 bool CheckCoinStakeTimestamp(int64 nTimeBlock, int64 nTimeTx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -978,7 +978,7 @@ int64 GetProofOfStakeReward(int64 nCoinAge, unsigned int nBits, unsigned int nTi
 {
     int64 nSubsidy = 0;
 
-    if ( (int64)nHeight > FORK_POS_REWARD_CHANGE )
+    if ( nTime > FORK_POS_REWARD_CHANGE )
         nSubsidy = GetProofOfStakeRewardV2(nCoinAge, nBits, nTime, nHeight, bCoinYearOnly);
     else
         nSubsidy = GetProofOfStakeRewardV1(nCoinAge, nBits, nTime, nHeight, bCoinYearOnly);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -976,36 +976,37 @@ double ConvertBitsToDouble(unsigned int nBits)
 
 int64 GetProofOfStakeReward(int64 nCoinAge, unsigned int nBits, unsigned int nTime, int nHeight, bool bCoinYearOnly)
 {
-	int64 nSubsidy = 0;
-	
-	if ( nTime > FORK_POS_REWARD_CHANGE )
-		nSubsidy = GetProofOfStakeRewardV2(nCoinAge, nBits, nTime, nHeight, bCoinYearOnly);
-	else
-		nSubsidy = GetProofOfStakeRewardV1(nCoinAge, nBits, nTime, nHeight, bCoinYearOnly);
-		
-	return nSubsidy;
-}	
+    int64 nSubsidy = 0;
+
+    if ( (int64)nHeight > FORK_POS_REWARD_CHANGE )
+        nSubsidy = GetProofOfStakeRewardV2(nCoinAge, nBits, nTime, nHeight, bCoinYearOnly);
+    else
+        nSubsidy = GetProofOfStakeRewardV1(nCoinAge, nBits, nTime, nHeight, bCoinYearOnly);
+
+    return nSubsidy;
+}
 
 int64 GetProofOfStakeRewardV1(int64 nCoinAge, unsigned int nBits, unsigned int nTime, int nHeight, bool bCoinYearOnly)
 {
     int64 nRewardCoinYear;
 
-	nRewardCoinYear = 1.5 * MIN_MINT_PROOF_OF_STAKE; // Set to Be Removed!
-    int64 nSubsidy = nCoinAge * nRewardCoinYear / 365; // Set to Be Removed!
-   
-	if (fDebug && GetBoolArg("-printcreation"))
+    nRewardCoinYear = 1.5 * MIN_MINT_PROOF_OF_STAKE;
+    int64 nSubsidy = nCoinAge * nRewardCoinYear / 365;
+
+    if(nSubsidy >= 10000){nSubsidy = 7000;}
+    if (fDebug && GetBoolArg("-printcreation"))
         printf("GetProofOfStakeReward(): create=%s nCoinAge=%"PRI64d" nBits=%d\n", FormatMoney(nSubsidy).c_str(), nCoinAge, nBits);
     return nSubsidy;
 }
 
 int64 GetProofOfStakeRewardV2(int64 nCoinAge, unsigned int nBits, unsigned int nTime, int nHeight, bool bCoinYearOnly)
 {
-	int64 nSubsidy = 5 * COIN;
-	
-	if (fDebug && GetBoolArg("-printcreation"))
+    int64 nSubsidy = 5 * COIN;
+
+    if (fDebug && GetBoolArg("-printcreation"))
         printf("GetProofOfStakeReward(): create=%s nCoinAge=%"PRI64d" nBits=%d\n", FormatMoney(nSubsidy).c_str(), nCoinAge, nBits);
     return nSubsidy;
-}	
+}
 
 static const int64 nTargetTimespan = 60 * 60;
 static const int64 nTargetSpacingWorkMax = 2 * nStakeTargetSpacing; 
@@ -2220,6 +2221,21 @@ bool CBlock::AcceptBlock()
     if (!Checkpoints::CheckHardened(nHeight, hash))
         return DoS(100, error("AcceptBlock() : rejected by hardened checkpoint lock-in at %d", nHeight));
 
+    // Verify hash target and signature of coinstake tx
+    if (IsProofOfStake())
+    {
+        uint256 hashProofOfStake = 0;
+        if (!CheckProofOfStake(vtx[1], nHeight, nBits, hashProofOfStake))
+        {
+            printf("WARNING: AcceptBlock(): check proof-of-stake failed for block %s\n", hash.ToString().c_str());
+            return false; // do not error here as we expect this during initial block download
+        }
+        if (!mapProofOfStake.count(hash)) // add to mapProofOfStake
+            mapProofOfStake.insert(make_pair(hash, hashProofOfStake));
+    }
+    
+    // PoW is checked in CheckBlock()
+
     bool cpSatisfies = Checkpoints::CheckSync(hash, pindexPrev); 
  
     // Check that the block satisfies synchronized checkpoint 
@@ -2316,23 +2332,6 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
     // Preliminary checks
     if (!pblock->CheckBlock())
         return error("ProcessBlock() : CheckBlock FAILED");
-
-    // verify hash target and signature of coinstake tx
-    if (pblock->IsProofOfStake())
-    {
-        uint256 hashProofOfStake = 0;
-        if (!CheckProofOfStake(pblock->vtx[1], pblock->nBits, hashProofOfStake))
-        {
-          // Ignore CheckProofOfStake() failure for hashHighBlock in order to speed up initial 
-	      // blockchain download. 
-	      if (pblock->GetHash() != hashHighBlock) { 
-		  printf("WARNING: ProcessBlock(): check proof-of-stake failed for block %s\n", hash.ToString().c_str()); 
-		  return false; // do not error here as we expect this during initial block download 
-	      }
-        }
-        if (!mapProofOfStake.count(hash)) // add to mapProofOfStake
-            mapProofOfStake.insert(make_pair(hash, hashProofOfStake));
-    }
 
     CBlockIndex* pcheckpoint = Checkpoints::GetLastSyncCheckpoint();
     if (pcheckpoint && pblock->hashPrevBlock != hashBestChain && !Checkpoints::WantedByPendingSyncCheckpoint(hash))

--- a/src/main.h
+++ b/src/main.h
@@ -41,7 +41,7 @@ static const int64 MAX_MONEY2 = 75000000000 * COIN;	// 75 Million DeOxyRibose
 static const int64 DEF_SPLIT_AMOUNT = 100 * COIN; 
 static const int64 MAX_SPLIT_AMOUNT = 10000 * COIN; 
 static const int64 MIN_MINT_PROOF_OF_STAKE = 3.71 * COIN;
-static const int64 FORK_POS_REWARD_CHANGE = 12500; // Block 12500 
+static const int64 FORK_POS_REWARD_CHANGE = 1431787253; // Block 12500 is ~ Sat, 16 May 2015 14:40:00 UTC
 
 static const int MAX_TIME_SINCE_BEST_BLOCK = 10;
 static const int64 MIN_TXOUT_AMOUNT = MIN_TX_FEE;

--- a/src/version.h
+++ b/src/version.h
@@ -25,13 +25,13 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 1001000;
+static const int PROTOCOL_VERSION = 1002000;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 10;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 1000000;
+static const int MIN_PEER_PROTO_VERSION = 1001000;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this
@@ -39,7 +39,7 @@ static const int CADDR_TIME_VERSION = 1000000;
 
 // only request blocks from nodes outside this range of versions
 static const int NOBLKS_VERSION_START = 1000000;
-static const int NOBLKS_VERSION_END = 1000000;
+static const int NOBLKS_VERSION_END = 1002000;
 
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 1000000;


### PR DESCRIPTION
Because the PoSV2 reward calculation was checking against the wrong variable (nTime instead of nHeight), I readjusted the calculation. If you read through the TruckCoin source, you will see exactly why this is the case. To give a brief summary, though, *nTime* requires a UTC time/date input and *nHeight* refers to the block height.

I also reverted the change to the PoSV1 reward because the blockchain has already passed it and it made no difference whatsoever.

Blockchain syncing needed fixing because people with less than 2500 blocks in their blockchains were unable to sync. This is an error I introduced in fixing PoS because I eliminated the previous stake modifier interval completely, rather than making a check to switch between the two. The code now checks blocks in a slightly different order to ensure that the proper blockchain height is passed to *CheckProofOfStake()*, which allows users to sync the entire blockchain from 0 to the current height without needing a blockchain download.

Blockchain checkpoints were also added to make sure people are syncing to the proper blockchain.