### PR TITLE
Redirecting IRC to new Rizon channel

### DIFF
--- a/src/qt/chatwindow.cpp
+++ b/src/qt/chatwindow.cpp
@@ -162,16 +162,16 @@ void ChatWindow::connecte()
     ui->tab->addTab(textEdit,"Console/PM");
 
 
-    ui->tab->setTabToolTip(ui->tab->count()-1,"irc.freenode.net");
+    ui->tab->setTabToolTip(ui->tab->count()-1,"irc.rizon.net");
     // current tab is now the last, therefore remove all but the last
     for (int i = ui->tab->count(); i > 1; --i) {
        ui->tab->removeTab(0);
     }
 
-    serveurs.insert("irc.freenode.net",serveur);
+    serveurs.insert("irc.rizon.net",serveur);
 
 	serveur->pseudo=ui->editPseudo->text();
-    serveur->serveur="irc.freenode.net";
+    serveur->serveur="irc.rizon.net";
     serveur->port=6667;
     serveur->affichage=textEdit;
     serveur->tab=ui->tab;
@@ -183,9 +183,9 @@ void ChatWindow::connecte()
 	connect(serveur, SIGNAL(joinTab()),this, SLOT(tabJoined() ));
 	connect(serveur, SIGNAL(tabJoined()),this, SLOT(tabJoining() ));
 
-   // serveur->connectToHost("irc.freenode.net",6667);
+   // serveur->connectToHost("irc.rizon.net",6667);
 
-        serveur->connectToHost("irc.freenode.net",6667);
+        serveur->connectToHost("irc.rizon.net",6667);
         //333
 
 	ui->tab->setCurrentIndex(ui->tab->count()-1);

--- a/src/qt/serveur.cpp
+++ b/src/qt/serveur.cpp
@@ -34,7 +34,7 @@ void Serveur::errorSocket(QAbstractSocket::SocketError error)
 	switch(error)
 	{
 		case QAbstractSocket::HostNotFoundError:
-            affichage->append(tr("<em>ERROR : can't find freenode server.</em>"));
+            affichage->append(tr("<em>ERROR : can't find Rizon server.</em>"));
 			break;
 		case QAbstractSocket::ConnectionRefusedError:
             affichage->append(tr("<em>ERROR : server refused connection</em>"));
@@ -53,7 +53,7 @@ void Serveur::connected()
 
 	sendData("USER "+pseudo+" localhost "+serveur+" :"+pseudo);
     sendData("NICK "+pseudo);
-    affichage->append("Connected to freenode.");
+    affichage->append("Connected to Rizon.");
 
 }
 
@@ -216,7 +216,7 @@ QString Serveur::parseCommande(QString comm,bool serveur)
                     destChan=msg.split(" ").first();
 
                 if(msgQuit=="")
-                    return "PART "+destChan+" using IrcLightClient";
+                    return "PART "+destChan+" using WalletIRC";
                 else
                     return "PART "+destChan+" "+msgQuit;
             }


### PR DESCRIPTION
The in-wallet IRC has not worked up to this point because it was
directed to Freenode, where the #deoxyribose channel did not
exist. A new #deoxyribose channel has been created at
irc.rizon.net. This commit redirects the wallet to Rizon's
server and allows the client to function as intended.