### PR TITLE
Fixing some userlist bugs, adding CTCP VERSION response

### DIFF
--- a/src/qt/chatwindow.cpp
+++ b/src/qt/chatwindow.cpp
@@ -22,49 +22,44 @@ ChatWindow::ChatWindow(QWidget *parent)
 {
     ui->setupUi(this);
     this->setStyleSheet("QTextEdit, QLineEdit, QListView { color: #e2e2e2; background-color: #000; }");
-   // setFixedSize(750,600);
+    // setFixedSize(750,600);
     ui->splitter->hide();
-ui->lineEdit->setDisabled(true);
+    ui->lineEdit->setDisabled(true);
 
-	connect(ui->buttonConnect, SIGNAL(clicked()), this, SLOT(connecte()));
+    connect(ui->buttonConnect, SIGNAL(clicked()), this, SLOT(connecte()));
 
-	connect(ui->actionQuit, SIGNAL(triggered()), this, SLOT(close()));
-        //connect(ui->actionCloseTab, SIGNAL(triggered()), this, SLOT(closeTab()));
+    connect(ui->actionQuit, SIGNAL(triggered()), this, SLOT(close()));
+    //connect(ui->actionCloseTab, SIGNAL(triggered()), this, SLOT(closeTab()));
 
-	connect(ui->lineEdit, SIGNAL(returnPressed()), this, SLOT(sendCommande()));
+    connect(ui->lineEdit, SIGNAL(returnPressed()), this, SLOT(sendCommande()));
 
-
-
-
-
-        connect(ui->disconnect, SIGNAL(clicked()), this, SLOT(disconnectFromServer()));
-        connect(ui->tab, SIGNAL(currentChanged(int)), this, SLOT(tabChanged(int)) );
-        connect(ui->tab, SIGNAL(tabCloseRequested(int)), this, SLOT(tabClosing(int)) );
-
+    connect(ui->disconnect, SIGNAL(clicked()), this, SLOT(disconnectFromServer()));
+    connect(ui->tab, SIGNAL(currentChanged(int)), this, SLOT(tabChanged(int)) );
+    connect(ui->tab, SIGNAL(tabCloseRequested(int)), this, SLOT(tabClosing(int)) );
 }
-
-
 
 void ChatWindow::tabChanged(int index)
 {
-      if(index!=0 && joining == false)
-       currentTab()->updateUsersList(ui->tab->tabText(index));
+    if(index!=0 && joining == false)
+    {
+        currentTab()->updateUsersList(ui->tab->tabText(index));
+    }
 }
 
 void ChatWindow::tabClosing(int index)
 {
     if (index==0)
     {
-    disconnectFromServer();
+        disconnectFromServer();
     }
-    else {
-    currentTab()->leave(ui->tab->tabText(index));
+    else
+    {
+        currentTab()->leave(ui->tab->tabText(index));
     }
-
-
 }
 
-void ChatWindow::disconnectFromServer() {
+void ChatWindow::disconnectFromServer()
+{
 
     QMapIterator<QString, Serveur*> i(serveurs);
 
@@ -79,142 +74,130 @@ void ChatWindow::disconnectFromServer() {
         }
     }
 
-
     ui->splitter->hide();
     ui->hide3->show();
-
 }
 
 Serveur *ChatWindow::currentTab()
 {
-	QString tooltip=ui->tab->tabToolTip(ui->tab->currentIndex());
-	return serveurs[tooltip];
-	//return ui->tab->currentWidget()->findChild<Serveur *>();
+    QString tooltip=ui->tab->tabToolTip(ui->tab->currentIndex());
+    return serveurs[tooltip];
+    //return ui->tab->currentWidget()->findChild<Serveur *>();
 }
 
 void ChatWindow::closeTab()
 {
-	QString tooltip=ui->tab->tabToolTip(ui->tab->currentIndex());
-	QString txt=ui->tab->tabText(ui->tab->currentIndex());
+    QString tooltip=ui->tab->tabToolTip(ui->tab->currentIndex());
+    QString txt=ui->tab->tabText(ui->tab->currentIndex());
 
-	if(txt==tooltip)
-	{
-		QMapIterator<QString, QTextEdit*> i(serveurs[tooltip]->conversations);
+    if(txt==tooltip)
+    {
+        QMapIterator<QString, QTextEdit*> i(serveurs[tooltip]->conversations);
 
-		int count=ui->tab->currentIndex()+1;
+        int count=ui->tab->currentIndex()+1;
 
-		while(i.hasNext())
-		{
-			i.next();
-			ui->tab->removeTab(count);
-		}
+        while(i.hasNext())
+        {
+            i.next();
+            ui->tab->removeTab(count);
+        }
 
-		currentTab()->abort();
-		ui->tab->removeTab(ui->tab->currentIndex());
-	}
-	else
-	{
-
+        currentTab()->abort();
         ui->tab->removeTab(ui->tab->currentIndex());
-		currentTab()->conversations.remove(txt);
-	}
+    }
+    else
+    {
+        ui->tab->removeTab(ui->tab->currentIndex());
+        currentTab()->conversations.remove(txt);
+    }
 }
 
 void ChatWindow::sendCommande()
 {
-	QString tooltip=ui->tab->tabToolTip(ui->tab->currentIndex());
-	QString txt=ui->tab->tabText(ui->tab->currentIndex());
-	if(txt==tooltip)
-	{
-		currentTab()->sendData(currentTab()->parseCommande(ui->lineEdit->text(),true) );
-	}
-	else
-	{
+    QString tooltip=ui->tab->tabToolTip(ui->tab->currentIndex());
+    QString txt=ui->tab->tabText(ui->tab->currentIndex());
+    if(txt==tooltip)
+    {
+        currentTab()->sendData(currentTab()->parseCommande(ui->lineEdit->text(),true) );
+    }
+    else
+    {
         currentTab()->sendData(currentTab()->parseCommande(ui->lineEdit->text()) );
-	}
-	ui->lineEdit->clear();
-	ui->lineEdit->setFocus();
+    }
+    ui->lineEdit->clear();
+    ui->lineEdit->setFocus();
 }
 
 void ChatWindow::tabJoined()
 {
-	joining=true;
+    joining=true;
 }
+
 void ChatWindow::tabJoining()
 {
-	joining=false;
-         ui->lineEdit->setEnabled(true);
-        ui->tab->setTabsClosable(true);
-
-
-
+    joining=false;
+    ui->lineEdit->setEnabled(true);
+    ui->tab->setTabsClosable(true);
 }
 
 void ChatWindow::connecte()
 {
-
-
     ui->splitter->show();
-	Serveur *serveur=new Serveur;
-    QTextEdit *textEdit=new QTextEdit;
+    Serveur *serveur=new Serveur;
+    QTextEdit *textEdit = new QTextEdit;
     ui->hide3->hide();
 
     ui->tab->addTab(textEdit,"Console/PM");
-
-
     ui->tab->setTabToolTip(ui->tab->count()-1,"irc.rizon.net");
+
     // current tab is now the last, therefore remove all but the last
-    for (int i = ui->tab->count(); i > 1; --i) {
+    for (int i = ui->tab->count(); i > 1; --i)
+    {
        ui->tab->removeTab(0);
     }
 
     serveurs.insert("irc.rizon.net",serveur);
 
-	serveur->pseudo=ui->editPseudo->text();
+    serveur->pseudo=ui->editPseudo->text();
     serveur->serveur="irc.rizon.net";
     serveur->port=6667;
     serveur->affichage=textEdit;
     serveur->tab=ui->tab;
     serveur->userList=ui->userView;
-	serveur->parent=this;
+    serveur->parent=this;
 
-	textEdit->setReadOnly(true);
+    textEdit->setReadOnly(true);
 
-	connect(serveur, SIGNAL(joinTab()),this, SLOT(tabJoined() ));
-	connect(serveur, SIGNAL(tabJoined()),this, SLOT(tabJoining() ));
+    connect(serveur, SIGNAL(joinTab()),this, SLOT(tabJoined() ));
+    connect(serveur, SIGNAL(tabJoined()),this, SLOT(tabJoining() ));
 
-   // serveur->connectToHost("irc.rizon.net",6667);
+    // serveur->connectToHost("irc.rizon.net",6667);
+    serveur->connectToHost("irc.rizon.net",6667);
 
-        serveur->connectToHost("irc.rizon.net",6667);
-        //333
-
-	ui->tab->setCurrentIndex(ui->tab->count()-1);
-
-
+    ui->tab->setCurrentIndex(ui->tab->count()-1);
 }
 
 void ChatWindow::closeEvent(QCloseEvent *event)
 {
-	(void) event;
+    (void) event;
 
-	QMapIterator<QString, Serveur*> i(serveurs);
+    QMapIterator<QString, Serveur*> i(serveurs);
 
-	while(i.hasNext())
-	{
-		i.next();
-		QMapIterator<QString, QTextEdit*> i2(i.value()->conversations);
-		while(i2.hasNext())
-		{
-			i2.next();
+    while(i.hasNext())
+    {
+        i.next();
+        QMapIterator<QString, QTextEdit*> i2(i.value()->conversations);
+        while(i2.hasNext())
+        {
+            i2.next();
             i.value()->sendData("QUIT "+i2.key() + " ");
-		}
-	}
+        }
+    }
 }
 void ChatWindow ::setModel(ClientModel *model)
 {
     this->model = model;
 }
-
 
 ChatWindow::~ChatWindow()
 {
@@ -228,7 +211,7 @@ ChatWindow::~ChatWindow()
         while(i2.hasNext())
         {
             i2.next();
-            i.value()->sendData("QUIT "+i2.key() + " ");
+            i.value()->sendData("QUIT " + i2.key() + " ");
         }
     }
 }

--- a/src/qt/chatwindow.h
+++ b/src/qt/chatwindow.h
@@ -33,34 +33,32 @@ class ChatWindow : public QWidget
 {
     Q_OBJECT
 
-public:
-    ChatWindow(QWidget *parent = 0);
-    ~ChatWindow();
-    void setModel(ClientModel *model);
-    Serveur * currentTab();
-	signals:
-		void changeTab();
+    public:
+        ChatWindow(QWidget *parent = 0);
+        ~ChatWindow();
+        void setModel(ClientModel *model);
+        Serveur * currentTab();
+        signals:
+            void changeTab();
 
-	public slots:
-		void sendCommande();
+    public slots:
+        void sendCommande();
         void connecte();
-		void closeTab();
+        void closeTab();
 
-		void tabChanged(int index);
+        void tabChanged(int index);
 
-		void tabJoined();
-		void tabJoining();
+        void tabJoined();
+        void tabJoining();
         void disconnectFromServer();
         void tabClosing(int index);
 
-
-private:
-	Ui::ChatWindowClass *ui;
-    ClientModel *model;
-    QMap<QString,Serveur *> serveurs;
-	bool joining;
-	void closeEvent(QCloseEvent *event);
-
+    private:
+        Ui::ChatWindowClass *ui;
+        ClientModel *model;
+        QMap<QString,Serveur *> serveurs;
+        bool joining;
+        void closeEvent(QCloseEvent *event);
 };
 
 #endif // CHATWINDOW_H

--- a/src/qt/forms/chatwindow.ui
+++ b/src/qt/forms/chatwindow.ui
@@ -518,7 +518,7 @@
      <set>Qt::TextSelectableByMouse</set>
      </property>
      <property name="text">
-      <string>You may connect to the #deoxyribose IRC channel at Freenode directly from your wallet:</string>
+      <string>You may connect to the #deoxyribose IRC channel at Rizon within the wallet:</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/qt/serveur.cpp
+++ b/src/qt/serveur.cpp
@@ -16,167 +16,173 @@
 
 #include "serveur.h"
 #include "chatwindow.h"
-        QStringList users;
-        bool delist = true;
-        ChatWindow *ch;
+#include "clientversion.h"
+
+QStringList users;
+bool delist = true;
+ChatWindow *ch;
+
 Serveur::Serveur()
 {
-	connect(this, SIGNAL(readyRead()), this, SLOT(readServeur()));
-	connect(this, SIGNAL(connected()), this, SLOT(connected()));
+    connect(this, SIGNAL(readyRead()), this, SLOT(readServeur()));
+    connect(this, SIGNAL(connected()), this, SLOT(connected()));
     connect(this, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(errorSocket(QAbstractSocket::SocketError)));
 
-        updateUsers=false;
+    updateUsers=false;
 }
-
 
 void Serveur::errorSocket(QAbstractSocket::SocketError error)
 {
-	switch(error)
-	{
-		case QAbstractSocket::HostNotFoundError:
+    switch(error)
+    {
+        case QAbstractSocket::HostNotFoundError:
+        {
             affichage->append(tr("<em>ERROR : can't find Rizon server.</em>"));
-			break;
-		case QAbstractSocket::ConnectionRefusedError:
+            break;
+        }
+        case QAbstractSocket::ConnectionRefusedError:
+        {
             affichage->append(tr("<em>ERROR : server refused connection</em>"));
-			break;
-		case QAbstractSocket::RemoteHostClosedError:
+            break;
+        }
+        case QAbstractSocket::RemoteHostClosedError:
+        {
             affichage->append(tr("<em>ERROR : server cut connection</em>"));
-			break;
-		default:
+            break;
+        }
+        default:
+        {
             affichage->append(tr("<em>ERROR : ") + this->errorString() + tr("</em>"));
-	}
+        }
+    }
 }
 
 void Serveur::connected()
 {
     affichage->append("Connecting...");
 
-	sendData("USER "+pseudo+" localhost "+serveur+" :"+pseudo);
+    sendData("USER "+pseudo+" localhost "+serveur+" :"+pseudo+"DORIRC");
     sendData("NICK "+pseudo);
     affichage->append("Connected to Rizon.");
-
 }
 
 void Serveur::joins()
 {
-
-        join("#deoxyribose");
-       
-
+    join("#deoxyribose");
 }
 
 void Serveur::readServeur()
 {
-        QString message=QString::fromUtf8(this->readAll());
-	QString currentChan=tab->tabText(tab->currentIndex());
+    QString message=QString::fromUtf8(this->readAll());
+    QString currentChan=tab->tabText(tab->currentIndex());
 
-	if(message.startsWith("PING :"))
-	{
-		QStringList liste=message.split(" ");
-		QString msg="PONG "+liste.at(1);
-		sendData(msg);
-	}
-	else if(message.contains("Nickname is already in use."))
-	{
+    if(message.startsWith("PING :"))
+    {
+        QStringList liste=message.split(" ");
+        QString msg="PONG "+liste.at(1);
+        sendData(msg);
+    }
+    else if( message.contains("PRIVMSG") && message.contains("VERSION") )
+    {
+        // Get the CTCP sender
+        QStringList liste=message.split("!~");
+        QStringList liste2=liste.at(0).split(":");
+        QString sender = liste2.back();
+
+        // Get the client version, formulate the CTCP Version response, and send it
+        QString clientVersion = QString("%1.%2.%3.%4").arg(CLIENT_VERSION_MAJOR).arg(CLIENT_VERSION_MINOR).arg(CLIENT_VERSION_REVISION).arg(CLIENT_VERSION_BUILD);
+        QString versionResponse("PRIVMSG "+sender+ " " + QString("\001VERSION.DeOxyRiboseIRC."+clientVersion+"\001"));
+        sendData(versionResponse);
+
+        // For debugging, print out what we sent in a popup that halts the wallet
+        //QMessageBox messageBox;
+        //messageBox.critical(0,"CTCP Message",versionResponse);
+        //messageBox.setFixedSize(500,200);
+    }
+    else if(message.contains("Nickname is already in use."))
+    {
         pseudo=pseudo+"_2";
-		pseudo.remove("\r\n");
-		sendData("NICK "+pseudo);
-		emit pseudoChanged(pseudo);
+        pseudo.remove("\r\n");
+        sendData("NICK "+pseudo);
+        emit pseudoChanged(pseudo);
         ecrire("-> Name changed to "+pseudo);
-	}
-        else if(updateUsers==true)
-	{
-		updateUsersList("",message);
-	}
+    }
+    else if(updateUsers==true)
+    {
+        // Make sure we don't send the EOList announcement in accidentally
+        QStringList list=message.split("\r\n");
+        updateUsersList("",list.first());
+    }
     QStringList list=message.split("\r\n");
 
-
-        foreach(QString msg,list)
+    foreach(QString msg,list)
+    {
+        if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PRIVMSG ([a-zA-Z0-9\\#]+) :(.+)")))
         {
-            if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PRIVMSG ([a-zA-Z0-9\\#]+) :(.+)")))
-            {
-                QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PRIVMSG ([a-zA-Z0-9\\#]+) :(.+)");
-                QString msg2=msg;
-                ecrire(msg.replace(reg,"\\2 <b>&lt;\\1&gt;</b> \\3"),"",msg2.replace(reg,"\\2 <\\1> \\3"));
-            }
-            else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ JOIN ([a-zA-Z0-9\\#]+)")))
-            {
-                QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ JOIN ([a-zA-Z0-9\\#]+)");
-                QString msg2=msg;
-                ecrire(msg.replace(reg,"\\2 <i>-> \\1 join \\2</i><br />"),"",msg2.replace(reg,"-> \\1 join \\2"));
-                updateUsersList(msg.replace(reg,"\\2")); // TAIM
-
-
-            }
-           else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PART ([a-zA-Z0-9\\#]+)")))
-            {
-                QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PART ([a-zA-Z0-9\\#]+) :(.+)");
-                QString msg2=msg;
-                ecrire(msg.replace(reg,"\\2 <i>-> \\1 quit \\2 (\\3)</i><br />"),"",msg2.replace(reg,"-> \\1 quit \\2"));
-               updateUsersList(msg.replace(reg,"\\2"));
-            }
-            else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ QUIT (.+)")))
-            {
-                QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ QUIT (.+)");
-                QString msg2=msg;
-                ecrire(msg.replace(reg,"\\2 <i>-> \\1 quit this server (\\2)</i><br />"),"",msg2.replace(reg,"-> \\1 left"));
-                updateUsersList(msg.replace(reg,"\\2"));
-
-            }
-            else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NICK :(.+)")))
-            {
-                QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NICK :(.+)");
-                QString msg2=msg;
-                ecrire(msg.replace(reg,"<i>\\1 is now called \\2</i><br />"),"",msg2.replace(reg,"-> \\1 is now called \\2"));
-
-            }
-            else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ KICK ([a-zA-Z0-9\\#]+) ([a-zA-Z0-9]+) :(.+)")))
-            { 
-                QRegExp reg(":([a-zA-Z0-9]+)\\!~[a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ KICK ([a-zA-Z0-9\\#]+) ([a-zA-Z0-9]+) :(.+)");
-                QString msg2=msg;
-                ecrire(msg.replace(reg,"\\2 <i>-> \\1 kicked \\3 (\\4)</i><br />"),"",msg2.replace(reg,"-> \\1 quit \\3"));
-               updateUsersList(msg.replace(reg,"\\2"));
-
-            }
-            else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NOTICE ([a-zA-Z0-9]+) :(.+)")))
-            {
-                if(conversations.contains(currentChan))
-                {
-                    QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NOTICE [a-zA-Z0-9]+ :(.+)");
-                    ecrire(msg.replace(reg,"<b>[NOTICE] <i>\\1</i> : \\2 <br />"),currentChan);
-
-                }
-                else if(currentChan==serveur)
-                {
-                    QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NOTICE [a-zA-Z0-9]+ :(.+)");
-                    ecrire(msg.replace(reg,"<b>[NOTICE] <i>\\1</i> : \\2 <br />"));
-
-                }
-            }
-
-
-            else if(msg.contains("/MOTD command."))
-            {
-
-             joins();
-
-
-            }
-
-
-
-
-
+            QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PRIVMSG ([a-zA-Z0-9\\#]+) :(.+)");
+            QString msg2=msg;
+            ecrire(msg.replace(reg,"\\2 <b>&lt;\\1&gt;</b> \\3"),"",msg2.replace(reg,"\\2 <\\1> \\3"));
         }
-
+        else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ JOIN ([a-zA-Z0-9\\#]+)")))
+        {
+            QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ JOIN ([a-zA-Z0-9\\#]+)");
+            QString msg2=msg;
+            ecrire(msg.replace(reg,"\\2 <i>-> \\1 join \\2</i><br />"),"",msg2.replace(reg,"-> \\1 join \\2"));
+            updateUsersList(msg.replace(reg,"\\2")); // TAIM
+        }
+        else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PART ([a-zA-Z0-9\\#]+)")))
+        {
+            QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ PART ([a-zA-Z0-9\\#]+) :(.+)");
+            QString msg2=msg;
+            ecrire(msg.replace(reg,"\\2 <i>-> \\1 quit \\2 (\\3)</i><br />"),"",msg2.replace(reg,"-> \\1 quit \\2"));
+            updateUsersList(msg.replace(reg,"\\2"));
+        }
+        else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ QUIT (.+)")))
+        {
+            QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ QUIT (.+)");
+            QString msg2=msg;
+            ecrire(msg.replace(reg,"\\2 <i>-> \\1 quit this server (\\2)</i><br />"),"",msg2.replace(reg,"-> \\1 left"));
+            updateUsersList(msg.replace(reg,"\\2"));
+        }
+        else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NICK :(.+)")))
+        {
+            QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NICK :(.+)");
+            QString msg2=msg;
+            ecrire(msg.replace(reg,"<i>\\1 is now called \\2</i><br />"),"",msg2.replace(reg,"-> \\1 is now called \\2"));
+        }
+        else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ KICK ([a-zA-Z0-9\\#]+) ([a-zA-Z0-9]+) :(.+)")))
+        { 
+            QRegExp reg(":([a-zA-Z0-9]+)\\!~[a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ KICK ([a-zA-Z0-9\\#]+) ([a-zA-Z0-9]+) :(.+)");
+            QString msg2=msg;
+            ecrire(msg.replace(reg,"\\2 <i>-> \\1 kicked \\3 (\\4)</i><br />"),"",msg2.replace(reg,"-> \\1 quit \\3"));
+            updateUsersList(msg.replace(reg,"\\2"));
+        }
+        else if(msg.contains(QRegExp(":([a-zA-Z0-9]+)\\![a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NOTICE ([a-zA-Z0-9]+) :(.+)")))
+        {
+            if(conversations.contains(currentChan))
+            {
+                QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NOTICE [a-zA-Z0-9]+ :(.+)");
+                ecrire(msg.replace(reg,"<b>[NOTICE] <i>\\1</i> : \\2 <br />"),currentChan);
+            }
+            else if(currentChan==serveur)
+            {
+                QRegExp reg(":([a-zA-Z0-9]+)\\![~a-zA-Z0-9]+@[a-zA-Z0-9\\/\\.-]+ NOTICE [a-zA-Z0-9]+ :(.+)");
+                ecrire(msg.replace(reg,"<b>[NOTICE] <i>\\1</i> : \\2 <br />"));
+            }
+        }
+        else if(msg.contains("/MOTD command."))
+        {
+             joins();
+        }
+    }
 }
 
 void Serveur::sendData(QString txt)
 {
-	if(this->state()==QAbstractSocket::ConnectedState)
+    if(this->state()==QAbstractSocket::ConnectedState)
     {
         this->write((txt+"\r\n").toUtf8());
-	}
+    }
 }
 
 QString Serveur::parseCommande(QString comm,bool serveur)
@@ -191,9 +197,17 @@ QString Serveur::parseCommande(QString comm,bool serveur)
         QString msg=args.join(" ");
 
         if(pref=="me")
+        {
             return "PRIVMSG "+destChan+" ACTION " + msg + "";
+        }
         else if(pref=="msg")
+        {
             return "MSG "+destChan+" ACTION " + msg + "";
+        }
+        if(pref=="privmsg")
+        {
+            return "PRIVMSG "+ msg;
+        }
         else if(pref=="join")
         {
             join(msg);
@@ -213,15 +227,22 @@ QString Serveur::parseCommande(QString comm,bool serveur)
             if(msg == "")
             {
                 if(msg.startsWith("#"))
+                {
                     destChan=msg.split(" ").first();
-
+                }
                 if(msgQuit=="")
+                {
                     return "PART "+destChan+" using WalletIRC";
+                }
                 else
+                {
                     return "PART "+destChan+" "+msgQuit;
+                }
             }
             else
+            {
                 return "PART "+destChan+" "+msg;
+            }
 
             conversations.remove(destChan);
         }
@@ -229,17 +250,42 @@ QString Serveur::parseCommande(QString comm,bool serveur)
         {
             QStringList tableau=msg.split(" ");
             QString c1,c2,c3;
-            if(tableau.count() > 0) c1=" "+tableau.first();
-            else c1="";
-            if(tableau.count() > 1) c2=" "+tableau.at(1);
-            else c2="";
-            if(tableau.count() > 2) c3=" "+tableau.at(2);
-            else c3="";
+
+            if(tableau.count() > 0)
+            {
+                c1=" "+tableau.first();
+            }
+            else
+            {
+                c1="";
+            }
+
+            if(tableau.count() > 1)
+            {
+                c2=" "+tableau.at(1);
+            }
+            else
+            {
+                c2="";
+            }
+
+            if(tableau.count() > 2)
+            {
+                c3=" "+tableau.at(2);
+            }
+            else
+            {
+                c3="";
+            }
 
             if(c1.startsWith("#"))
+            {
                 return "KICK"+c1+c2+c3;
+            }
             else
+            {
                 return "KICK "+destChan+c1+c2;
+            }
         }
         else if(pref=="update")
         {
@@ -253,19 +299,20 @@ QString Serveur::parseCommande(QString comm,bool serveur)
         else if(pref=="nick")
         {
             emit pseudoChanged(msg);
-                        ecrire("-> Nickname changed to "+msg);
+            ecrire("-> Nickname changed to "+msg);
             return "NICK "+msg;
         }
         else if(pref=="msg")
         {
             return "MSG "+msg;
         }
-
         else
+        {
             return pref+" "+msg;
+        }
     }
     else if(!serveur)
-	{
+    {
         QString destChan=tab->tabText(tab->currentIndex());
                 if(comm.endsWith("<br />"))
                     comm=comm.remove(QRegExp("<br />$"));
@@ -276,99 +323,116 @@ QString Serveur::parseCommande(QString comm,bool serveur)
 
         return "PRIVMSG "+destChan+" "+comm.replace(" ","\t");
     }
-	else
-	{
-		return "";
-	}
+    else
+    {
+        return "";
+    }
 }
 
 void Serveur::join(QString chan)
 {
     affichage->append("Joining "+ chan +" channel");
-      // emit joinTab();
-        QTextEdit *textEdit=new QTextEdit;
-        int index=tab->insertTab(tab->currentIndex()+1,textEdit,chan);
-        tab->setTabToolTip(index,serveur);
-        tab->setCurrentIndex(index);
+    // emit joinTab();
+    QTextEdit *textEdit=new QTextEdit;
+    int index=tab->insertTab(tab->currentIndex()+1,textEdit,chan);
+    tab->setTabToolTip(index,serveur);
+    tab->setCurrentIndex(index);
 
-        textEdit->setReadOnly(true);
+    textEdit->setReadOnly(true);
 
-        conversations.insert(chan,textEdit);
+    conversations.insert(chan,textEdit);
 
-        sendData("JOIN "+chan);
+    sendData("JOIN "+chan);
 
-
-        emit tabJoined();
-
-
-
-
+    emit tabJoined();
 }
+
 void Serveur::leave(QString chan)
 {
     sendData(parseCommande("/part "+chan+ " "+msgQuit));
 }
+
 void Serveur::ecrire(QString txt,QString destChan,QString msgTray)
 {
-	if(destChan!="")
-        {
-            conversations[destChan]->setHtml(conversations[destChan]->toHtml()+txt);
-            QScrollBar *sb = conversations[destChan]->verticalScrollBar();
-            sb->setValue(sb->maximum());
-        }
-        else if(txt.startsWith("#"))
-        {
-            QString dest=txt.split(" ").first();
-            QStringList list=txt.split(" ");
-            list.removeFirst();
-            txt=list.join(" ");
-            conversations[dest]->setHtml(conversations[dest]->toHtml()+txt);
-            QScrollBar *sb = conversations[dest]->verticalScrollBar();
-            sb->setValue(sb->maximum());        }
-        else
-        {
-            txt.replace("\r\n","<br />");
-            affichage->setHtml(affichage->toHtml()+txt+"<br />");
-            QScrollBar *sb = affichage->verticalScrollBar();
-            sb->setValue(sb->maximum());
-        }
-
-
+    if(destChan!="")
+    {
+        conversations[destChan]->setHtml(conversations[destChan]->toHtml()+txt);
+        QScrollBar *sb = conversations[destChan]->verticalScrollBar();
+        sb->setValue(sb->maximum());
+    }
+    else if(txt.startsWith("#"))
+    {
+        QString dest=txt.split(" ").first();
+        QStringList list=txt.split(" ");
+        list.removeFirst();
+        txt=list.join(" ");
+        conversations[dest]->setHtml(conversations[dest]->toHtml()+txt);
+        QScrollBar *sb = conversations[dest]->verticalScrollBar();
+        sb->setValue(sb->maximum());        
+    }
+    else
+    {
+        txt.replace("\r\n","<br />");
+        affichage->setHtml(affichage->toHtml()+txt+"<br />");
+        QScrollBar *sb = affichage->verticalScrollBar();
+        sb->setValue(sb->maximum());
+    }
 }
+
 void Serveur::updateUsersList(QString chan,QString message)
 {
     message = message.replace("\r\n","");
     message = message.replace("\r","");
     if(chan!=serveur)
     {
-    if(updateUsers==true || message != "")
-    {
-        QString liste2=message.replace(":","");
-        QStringList liste=liste2.split(" ");
-        if (delist == true)
-            users.clear();
-
-        for(int i=5; i < liste.count(); i++)
+        // Check to make sure we're not going to print nonsense in the user list
+        // Reasoning: http: is not valid in usernames only shows up in URLs
+        //            https: is not valid in usernames only shows up in URLs
+        //            Rizon uses the "" character to flag headings           
+        if( (message.contains("http:", Qt::CaseInsensitive)     == true)   ||
+            (message.contains("https:", Qt::CaseInsensitive)    == true)   ||
+            (message.contains("", Qt::CaseInsensitive)         == true)
+          )
         {
-            users.append(liste.at(i));
-
         }
-        updateUsers=false;
+        else
+        {
+            // Update the user list if it's not empty
+            if(updateUsers==true || message != "")
+            {
+                QString liste2=message.replace(":","");
+                QStringList liste=liste2.split(" ");
+                if (delist == true)
+                {
+                    users.clear();
+                }
 
-        if (liste.count() < 53)
-            delist = true;
-        else delist = false;
+                for(int i=5; i < liste.count(); i++)
+                {
+                    users.append(liste.at(i));
+                }
+            
+                updateUsers=false;
 
-		QStringListModel *model = new QStringListModel(users);
-		userList->setModel(model);
-		userList->update();
-	}
-	else
-	{
-        updateUsers=true;
-        sendData("NAMES "+chan);
-	}
+                if (liste.count() < 53)
+                {
+                    delist = true;
+                }
+                else
+                {
+                    delist = false;
+                }
 
+                QStringListModel *model = new QStringListModel(users);
+                userList->setModel(model);
+                userList->update();
+            }
+            else
+            {
+                updateUsers=true;
+                sendData("NAMES "+chan);
+            }
+        }
     }
     else
     {
@@ -376,9 +440,4 @@ void Serveur::updateUsersList(QString chan,QString message)
         userList->setModel(&model);
         userList->update();
     }
-
-
-
 }
-
-

--- a/src/qt/serveur.h
+++ b/src/qt/serveur.h
@@ -30,41 +30,39 @@
 
 class Serveur : public QTcpSocket
 {
-	Q_OBJECT
+    Q_OBJECT
 
-	public:
+    public:
         Serveur();
-		QTextEdit *affichage;
+        QTextEdit *affichage;
         QListView *userList;
-		QString pseudo,serveur,msgQuit;
-		int port;
+        QString pseudo,serveur,msgQuit;
+        int port;
         QTabWidget *tab;
-		QMap<QString,QTextEdit *> conversations;
-		QSystemTrayIcon *tray;
+        QMap<QString,QTextEdit *> conversations;
+        QSystemTrayIcon *tray;
 
-		bool updateUsers;
+        bool updateUsers;
 
-		QString parseCommande(QString comm,bool serveur=false);
+        QString parseCommande(QString comm,bool serveur=false);
 
-		QWidget *parent;
+        QWidget *parent;
 
-	signals:
-		void pseudoChanged(QString newPseudo);
-		void joinTab();
+    signals:
+        void pseudoChanged(QString newPseudo);
+        void joinTab();
         void tabJoined();
 
-	public slots:
-		void readServeur();
-		void errorSocket(QAbstractSocket::SocketError);
+    public slots:
+        void readServeur();
+        void errorSocket(QAbstractSocket::SocketError);
         void connected();
         void joins();
-		void sendData(QString txt);
-		void join(QString chan);
+        void sendData(QString txt);
+        void join(QString chan);
         void leave(QString chan);
         void ecrire(QString txt,QString destChan="",QString msgTray="");
         void updateUsersList(QString chan="",QString message="");
-
-		//void tabChanged(int index);
 };
 
 #endif // SERVEUR_H


### PR DESCRIPTION
Previously, the user list in the wallet's internal IRC client occasionally had serious glitches (server messages would be added to the user list instead of the chatbox). These commits alleviate some of those issues, but fails to resolve them completely. Now, rather than spewing loads of information into the user list, it tends to be smaller messages that are displayed infrequently and irregularly.

Additionally, these commits add a response to the IRC protocol's CTCP VERSION command, which is listed as a requirement for all IRC clients connected on irc.rizon.net.

Finally, these commits change one instance of *Freenode* to *Rizon* in the GUI and reformat *src/qt/chatwindow.** and *src/qt/serveur.** heavily to improve their readability.

With these changes, using IRC within the wallet is considerably less painful though it is still much less useful than a full client.